### PR TITLE
irqchip: gic-v3: Collection table support muti pages

### DIFF
--- a/drivers/irqchip/irq-gic-v3-its.c
+++ b/drivers/irqchip/irq-gic-v3-its.c
@@ -2632,6 +2632,10 @@ static int its_alloc_tables(struct its_node *its)
 			indirect = its_parse_indirect_baser(its, baser, &order,
 							    ITS_MAX_VPEID_BITS);
 			break;
+		case GITS_BASER_TYPE_COLLECTION:
+			indirect = its_parse_indirect_baser(its, baser, &order,
+							order_base_2(num_possible_cpus()));
+			break;
 		}
 
 		err = its_setup_baser(its, baser, cache, shr, order, indirect);


### PR DESCRIPTION
driver inclusion
category: bugfix
bugzilla: https://gitee.com/openeuler/kernel/issues/I7CX6S CVE: NA

--------------------------------------------------------------------------

Only one page is allocated to the collection table. Recalculate the page number of collection table based on the number of CPUs.