### PR TITLE
ACPI: CPPC: fix bug that causes the value written in cpc register to be wrong.

### DIFF
--- a/drivers/acpi/cppc_acpi.c
+++ b/drivers/acpi/cppc_acpi.c
@@ -1142,7 +1142,6 @@ static int cpc_write(int cpu, struct cpc_register_resource *reg_res, u64 val)
 			return -EFAULT;
 		}
 		val = MASK_VAL_WRITE(reg, prev_val, val);
-		val |= prev_val;
 	}
 
 	switch (size) {


### PR DESCRIPTION
mainline inclusion
from mainline-v6.13-rc1
commit 2388b266c9fcc7c9169ba85c7f9ebe325b7622d7
bugzilla: https://gitee.com/openeuler/kernel/issues/IB5JJG CVE: NA

--------------------------------

With these codes, the value written in cpc register will be the result of the OR operatiion on input value and prev_val. This will causes the value to be wrong.