### PR TITLE
ACPI: PCC: Add PCC shared memory region command and status bitfields

### DIFF
--- a/include/acpi/pcc.h
+++ b/include/acpi/pcc.h
@@ -18,7 +18,20 @@ struct pcc_mbox_chan {
 	u16 min_turnaround_time;
 };
 
+/* Generic Communications Channel Shared Memory Region */
+#define PCC_SIGNATURE			0x50434300
+/* Generic Communications Channel Command Field */
+#define PCC_CMD_GENERATE_DB_INTR	BIT(15)
+/* Generic Communications Channel Status Field */
+#define PCC_STATUS_CMD_COMPLETE		BIT(0)
+#define PCC_STATUS_SCI_DOORBELL		BIT(1)
+#define PCC_STATUS_ERROR		BIT(2)
+#define PCC_STATUS_PLATFORM_NOTIFY	BIT(3)
+/* Initiator Responder Communications Channel Flags */
+#define PCC_CMD_COMPLETION_NOTIFY	BIT(0)
+
 #define MAX_PCC_SUBSPACES	256
+
 #ifdef CONFIG_PCC
 extern struct pcc_mbox_chan *
 pcc_mbox_request_channel(struct mbox_client *cl, int subspace_id);


### PR DESCRIPTION
mainline inclusion
from mainline-v6.7-rc1
commit 55d235ebb684b993b3247740c1c8e273f8af4a54
category: feature
bugzilla: https://gitee.com/openeuler/kernel/issues/I8Y3PY CVE: NA

Reference: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?h=v6.6-rc1&id=55d235ebb684b993b3247740c1c8e273f8af4a54

--------------------------------

Define the common macros to use when referring to various bitfields in the PCC generic communications channel command and status fields.

Currently different drivers that need to use these bitfields have defined these locally. This common macro is intended to consolidate and replace those.

Cc: "Rafael J. Wysocki" <rafael.j.wysocki@intel.com>
Link: https://lore.kernel.org/r/20230927-pcc_defines-v2-1-0b8ffeaef2e5@arm.com