### PR TITLE
perf hisi-ptt: Fix memory leak in lseek failure handling

### DIFF
--- a/tools/perf/util/hisi-ptt.c
+++ b/tools/perf/util/hisi-ptt.c
@@ -108,8 +108,10 @@ static int hisi_ptt_process_auxtrace_event(struct perf_session *session,
 		data_offset = 0;
 	} else {
 		data_offset = lseek(fd, 0, SEEK_CUR);
-		if (data_offset == -1)
+		if (data_offset == -1) {
+			free(data);
 			return -errno;
+		}
 	}
 
 	err = readn(fd, data, size);


### PR DESCRIPTION
In the previous code, there was a memory leak issue where the previously allocated memory was not freed upon a failed lseek operation. This patch addresses the problem by releasing the old memory before returning -errno in case of a lseek failure. This ensures that memory is properly managed and avoids potential memory leaks.


Acked-by: Namhyung Kim <namhyung@kernel.org>
Cc: yangyicong@hisilicon.com
Cc: jonathan.cameron@huawei.com
Link: https://lore.kernel.org/r/20230930072719.1267784-1-visitorckw@gmail.com